### PR TITLE
Fix #51 batch size == dataset size issue

### DIFF
--- a/src/main/scala/WeaviateDataWriter.scala
+++ b/src/main/scala/WeaviateDataWriter.scala
@@ -23,6 +23,7 @@ case class WeaviateDataWriter(weaviateOptions: WeaviateOptions, schema: StructTy
   }
 
   def writeBatch(retries: Int = weaviateOptions.retries): Unit = {
+    if (batch.size == 0) return
     val client = weaviateOptions.getClient()
     val results = client.batch().objectsBatcher().withObjects(batch.values.toList: _*).run()
     val IDs = batch.keys.toList

--- a/src/test/scala/SparkIntegrationTest.scala
+++ b/src/test/scala/SparkIntegrationTest.scala
@@ -169,6 +169,99 @@ class SparkIntegrationTest
     WeaviateDocker.deleteClass()
   }
 
+  test("Test dataset size equal batch size") {
+    WeaviateDocker.createClass()
+    import spark.implicits._
+    val articles = (1 to 10).map(_ => Article("", "", 0)).toDF
+
+    articles.write
+      .format("io.weaviate.spark.Weaviate")
+      .option("scheme", "http")
+      .option("host", "localhost:8080")
+      .option("className", "Article")
+      .option("batchSize", 10)
+      .mode("append")
+      .save()
+
+    val results = client.data().objectsGetter()
+      .withClassName("Article")
+      .run()
+
+    if (results.hasErrors) {
+      println("Error getting Articles" + results.getError.getMessages)
+    }
+    assert(results.getResult.size == 10)
+    val props = (0 to 10 - 1).map(i => results.getResult.get(i).getProperties)
+    results.getResult.forEach(obj => {
+      assert(obj.getProperties.get("wordCount") == 0)
+      assert(obj.getProperties.get("content") == "")
+      assert(obj.getProperties.get("title") == "")
+    })
+    WeaviateDocker.deleteClass()
+  }
+
+  test("Test dataset size being 1 less than batch size") {
+    WeaviateDocker.createClass()
+    import spark.implicits._
+    val articles = (1 to 9).map(_ => Article("", "", 0)).toDF
+
+    articles.write
+      .format("io.weaviate.spark.Weaviate")
+      .option("scheme", "http")
+      .option("host", "localhost:8080")
+      .option("className", "Article")
+      .option("batchSize", 9)
+      .mode("append")
+      .save()
+
+    val results = client.data().objectsGetter()
+      .withClassName("Article")
+      .run()
+
+    if (results.hasErrors) {
+      println("Error getting Articles" + results.getError.getMessages)
+    }
+    assert(results.getResult.size == 9)
+    val props = (0 to 9 - 1).map(i => results.getResult.get(i).getProperties)
+    results.getResult.forEach(obj => {
+      assert(obj.getProperties.get("wordCount") == 0)
+      assert(obj.getProperties.get("content") == "")
+      assert(obj.getProperties.get("title") == "")
+    })
+    WeaviateDocker.deleteClass()
+  }
+
+  test("Test dataset size being 1 more than batch size") {
+    WeaviateDocker.createClass()
+    import spark.implicits._
+    val articles = (1 to 11).map(_ => Article("", "", 0)).toDF
+
+    articles.write
+      .format("io.weaviate.spark.Weaviate")
+      .option("scheme", "http")
+      .option("host", "localhost:8080")
+      .option("className", "Article")
+      .option("batchSize", 11)
+      .mode("append")
+      .save()
+
+    val results = client.data().objectsGetter()
+      .withClassName("Article")
+      .run()
+
+    if (results.hasErrors) {
+      println("Error getting Articles" + results.getError.getMessages)
+    }
+    assert(results.getResult.size == 11)
+    val props = (0 to 11 - 1).map(i => results.getResult.get(i).getProperties)
+    results.getResult.forEach(obj => {
+      assert(obj.getProperties.get("wordCount") == 0)
+      assert(obj.getProperties.get("content") == "")
+      assert(obj.getProperties.get("title") == "")
+    })
+    WeaviateDocker.deleteClass()
+  }
+
   test("Article different order") {
     WeaviateDocker.createClass()
     import spark.implicits._


### PR DESCRIPTION
Commit calls writeBatch also after a valid batch write, however when commit calls writeBatch there are no objects in the batch anymore. This was causing a null pointer exception.

This is fixed by a simple check in writeBatch to simply skip if there are no objects in the batch.

This fixes [#51 ](https://github.com/weaviate/spark-connector/issues/51)