### PR TITLE
Add support for Weaviate client custom headers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,8 @@ ThisBuild / assemblyMergeStrategy  := {
     oldStrategy(x)
 }
 
+Test / parallelExecution := false
+
 // Remove all additional repository other than Maven Central from POM
 pomIncludeRepository := { _ => false }
 publishMavenStyle := true

--- a/src/test/scala/SparkIntegrationTest.scala
+++ b/src/test/scala/SparkIntegrationTest.scala
@@ -646,7 +646,8 @@ class SparkIntegrationTest
       println("Error getting Articles" + results.getError.getMessages)
     }
 
-    assert(results.getResult.size == 0)
+    assert(results.getResult.size == 1)
+    assert(results.getResult.get(0).getVector == null)
   }
 }
 

--- a/src/test/scala/TestWeaviateOptions.scala
+++ b/src/test/scala/TestWeaviateOptions.scala
@@ -152,6 +152,32 @@ class TestWeaviateOptions extends AnyFunSuite {
     assert(weaviateOptions.oidcRefreshToken == "refreshToken")
   }
 
+  test("Test that headers are added correctly") {
+    val options: CaseInsensitiveStringMap =
+      new CaseInsensitiveStringMap(Map("scheme" -> "http", "host" -> "localhost",
+        "className" -> "pinball", "batchSize" -> "19", "retries" -> "5", "retriesBackoff" -> "5",
+        "oidc:accessToken" -> "accessToken", "oidc:accessTokenLifetime" -> "100", "oidc:refreshToken" -> "refreshToken",
+        "header:X-OpenAI-Api-Key" -> "OPENAI_KEY", "header:X-Cohere-Api-Key" -> "COHERE_KEY").asJava)
+    val weaviateOptions: WeaviateOptions = new WeaviateOptions(options)
+
+    assert(weaviateOptions.scheme == "http")
+    assert(weaviateOptions.host == "localhost")
+    assert(weaviateOptions.className == "pinball")
+    assert(weaviateOptions.batchSize == 19)
+    assert(weaviateOptions.retries == 5)
+    assert(weaviateOptions.retriesBackoff == 5)
+    assert(weaviateOptions.timeout == 60)
+    assert(weaviateOptions.oidcUsername == "")
+    assert(weaviateOptions.oidcPassword == "")
+    assert(weaviateOptions.oidcClientSecret == "")
+    assert(weaviateOptions.oidcAccessToken == "accessToken")
+    assert(weaviateOptions.oidcAccessTokenLifetime == 100)
+    assert(weaviateOptions.oidcRefreshToken == "refreshToken")
+    assert(weaviateOptions.headers.size == 2)
+    assert(weaviateOptions.headers.asJava.get("x-openai-api-key") == "OPENAI_KEY")
+    assert(weaviateOptions.headers.asJava.get("x-cohere-api-key") == "COHERE_KEY")
+  }
+
   test("Test that getConnection returns the same WeaviateClient object") {
     val options: CaseInsensitiveStringMap =
       new CaseInsensitiveStringMap(Map("scheme" -> "http", "host" -> "localhost:8080", "className" -> "pinball", "batchSize" -> "19").asJava)

--- a/src/test/scala/WeaviateDocker.scala
+++ b/src/test/scala/WeaviateDocker.scala
@@ -18,7 +18,7 @@ object WeaviateDocker {
   var retries = 5
 
   def start(vectorizerModule: String = "none", enableModules: String = "text2vec-openai"): Int = {
-    val weaviateVersion = "1.17.1"
+    val weaviateVersion = "1.18.2"
     val docker_run =
       s"""docker run -d --name=weaviate-test-container-will-be-deleted
 -p 8080:8080

--- a/src/test/scala/WeaviateDocker.scala
+++ b/src/test/scala/WeaviateDocker.scala
@@ -15,7 +15,7 @@ object WeaviateDocker {
     (o: String) => println("out " + o),
     (e: String) => println("err " + e))
 
-  var retries = 5
+  var retries = 10
 
   def start(vectorizerModule: String = "none", enableModules: String = "text2vec-openai"): Int = {
     val weaviateVersion = "1.18.2"
@@ -63,13 +63,13 @@ semitechnologies/weaviate:$weaviateVersion"""
       println("insert error" + results.getError.getMessages)
       if (retries > 1) {
         retries -= 1
-        println("Retrying to create class in 1 seconds..")
-        Thread.sleep(1000)
+        println("Retrying to create class in 0.1 seconds..")
+        Thread.sleep(100)
         createClass(additionalProperties: _*)
       }
     }
     println("Results: " + results.getResult)
-    retries = 5
+    retries = 10
   }
 
   def deleteClass(): Unit = {

--- a/src/test/scala/WeaviateDocker.scala
+++ b/src/test/scala/WeaviateDocker.scala
@@ -17,14 +17,15 @@ object WeaviateDocker {
 
   var retries = 5
 
-  def start(): Int = {
+  def start(vectorizerModule: String = "none", enableModules: String = "text2vec-openai"): Int = {
     val weaviateVersion = "1.17.1"
     val docker_run =
       s"""docker run -d --name=weaviate-test-container-will-be-deleted
 -p 8080:8080
 -e QUERY_DEFAULTS_LIMIT=25
 -e AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true
--e DEFAULT_VECTORIZER_MODULE=none
+-e DEFAULT_VECTORIZER_MODULE=$vectorizerModule
+-e ENABLE_MODULES=$enableModules
 -e CLUSTER_HOSTNAME=node1
 -e PERSISTENCE_DATA_PATH=./data
 semitechnologies/weaviate:$weaviateVersion"""


### PR DESCRIPTION
This PR adds support for Weaviate client custom headers:

```
options.option("header:X-OpenAI-API-Key", <OPENAI-KEY>).option("header:X-Cohere-API-Key", <COHERE-KEY>)
```

Closes #78 