### PR TITLE
Update dependencies to latest versions, adjust tests to Weaviate v1.19 version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,14 +12,14 @@ lazy val root = (project in file("."))
 
 ThisBuild / scalafixDependencies += "org.scalalint" %% "rules" % "0.1.4"
 
-lazy val sparkVersion = "3.3.1"
-lazy val weaviateClientVersion = "4.0.1"
+lazy val sparkVersion = "3.4.0"
+lazy val weaviateClientVersion = "4.1.0"
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.14" % "test",
+  "org.scalatest" %% "scalatest" % "3.2.15" % "test",
   "org.apache.spark" %% "spark-core" % sparkVersion % "provided,test",
   "org.apache.spark" %% "spark-sql" % sparkVersion % "provided,test",
   "org.apache.spark" %% "spark-catalyst" % sparkVersion % "provided,test",
-  "org.scala-lang.modules" %% "scala-collection-compat" % "2.9.0",
+  "org.scala-lang.modules" %% "scala-collection-compat" % "2.10.0",
   "io.weaviate" % "client" % weaviateClientVersion
 )
 

--- a/src/test/python/event_schema.py
+++ b/src/test/python/event_schema.py
@@ -6,32 +6,32 @@ event_schema = {
     "description": "A page on the internet",
     "properties": [
         #                {
-        #                    "dataType": ["string"],
+        #                    "dataType": ["text"],
         #                    "description": "Domain of the page",
         #                    "name": "domain",
         #                },
         #                {
-        #                    "dataType": ["string"],
+        #                    "dataType": ["text"],
         #                    "description": "URL of the page",
         #                    "name": "og_url",
         #                },
         #                {
-        #                    "dataType": ["string"],
+        #                    "dataType": ["text"],
         #                    "description": "Title of the page",
         #                    "name": "title"
         #                },
         {
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "MONEY",
             "name": "moneyline"
         },
         #                {
-        #                    "dataType": ["string"],
+        #                    "dataType": ["text"],
         #                    "description": "time left",
         #                    "name": "game_clock"
         #                },
         {
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "current period",
             "name": "current_period",
         },
@@ -41,22 +41,22 @@ event_schema = {
             "name": "is_live",
         },
         # {
-        #                    "dataType": ["string"],
+        #                    "dataType": ["text"],
         #                    "description": "over_under",
         #                    "name": "over_under"
         #                },
         {
-            "dataType": ["string[]"],
+            "dataType": ["text[]"],
             "description": "lotta plays",
             "name": "plays"
         },
         {
-            "dataType": ["string[]"],
+            "dataType": ["text[]"],
             "description": "lotta scores",
             "name": "scores"
         },
         {
-            "dataType": ["string[]"],
+            "dataType": ["text[]"],
             "description": "lotta teams",
             "name": "teams"
         }

--- a/src/test/python/movie_schema.py
+++ b/src/test/python/movie_schema.py
@@ -19,47 +19,47 @@ movie_schema = {
         },
         {
             "name": "url",
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "The IMBD url of the movie",
         },
         {
             "name": "title",
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "The name of the movie",
         },
         {
             "name": "poster_link",
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "The poster link of the movie",
         },
         {
             "name": "genres",
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "The genres of the movie",
         },
         {
             "name": "actors",
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "The actors of the movie",
         },
         {
             "name": "director",
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "Director of the movie",
         },
         {
             "name": "description",
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "overview of the movie",
         },
         {
             "name": "date_published",
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "The date on which movie was published",
         },
         {
             "name": "keywords",
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "main keywords of the movie",
         },
         {
@@ -69,22 +69,22 @@ movie_schema = {
         },
         {
             "name": "review_aurthor",
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "aurthor of the review",
         },
         {
             "name": "review_date",
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "date of review",
         },
         {
             "name": "review_body",
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "body of the review",
         },
         {
             "name": "duration",
-            "dataType": ["string"],
+            "dataType": ["text"],
             "description": "the duration of the review",
         }
     ]

--- a/src/test/python/requirements.txt
+++ b/src/test/python/requirements.txt
@@ -1,4 +1,4 @@
-pyspark==3.3.1
+pyspark==3.4.0
 pytest
 docker
 weaviate-client

--- a/src/test/python/test_spark.py
+++ b/src/test/python/test_spark.py
@@ -31,7 +31,7 @@ def get_connector_version():
 
 connector_version = os.environ.get("CONNECTOR_VERSION", get_connector_version())
 scala_version = os.environ.get("SCALA_VERSION", "2.12")
-weaviate_version = os.environ.get("WEAVIATE_VERSION", "1.17.2")
+weaviate_version = os.environ.get("WEAVIATE_VERSION", "1.19.0")
 spark_connector_jar_path = os.environ.get(
     "CONNECTOR_JAR_PATH", f"target/scala-{scala_version}/spark-connector-assembly-{connector_version}.jar"
 )
@@ -44,7 +44,7 @@ def spark():
         .appName("Weaviate Pyspark Tests")
         .master('local')
         .config("spark.jars", spark_connector_jar_path)
-        .config("spark.jars.packages", "org.apache.spark:spark-sql-kafka-0-10_2.12:3.3.1")
+        .config("spark.jars.packages", "org.apache.spark:spark-sql-kafka-0-10_2.12:3.4.0")
         .config("spark.driver.host", "127.0.0.1")
         .getOrCreate()
     )

--- a/src/test/scala/SparkIntegrationTest.scala
+++ b/src/test/scala/SparkIntegrationTest.scala
@@ -120,7 +120,7 @@ class SparkIntegrationTest
         .name("keywords")
         .build(),
       Property.builder()
-        .dataType(List[String]("string").asJava)
+        .dataType(List[String]("text").asJava)
         .name("customId")
         .build(),
       Property.builder()

--- a/src/test/scala/WeaviateDocker.scala
+++ b/src/test/scala/WeaviateDocker.scala
@@ -18,7 +18,7 @@ object WeaviateDocker {
   var retries = 10
 
   def start(vectorizerModule: String = "none", enableModules: String = "text2vec-openai"): Int = {
-    val weaviateVersion = "1.18.2"
+    val weaviateVersion = "1.19.0"
     val docker_run =
       s"""docker run -d --name=weaviate-test-container-will-be-deleted
 -p 8080:8080
@@ -41,11 +41,11 @@ semitechnologies/weaviate:$weaviateVersion"""
   def createClass(additionalProperties: Property*): Unit = {
     val properties = Seq(
       Property.builder()
-        .dataType(List[String]("string").asJava)
+        .dataType(List[String]("text").asJava)
         .name("title")
         .build(),
       Property.builder()
-        .dataType(List[String]("string").asJava)
+        .dataType(List[String]("text").asJava)
         .name("content")
         .build(),
       Property.builder()


### PR DESCRIPTION
This PR updates dependencies to latest versions and adjusts the tests to `v1.19` version of Weaviate, where we have deprecated `string` data type in favor of `text`