### PR TITLE
Fix NPE with unresponsive Weaviate server

### DIFF
--- a/src/test/scala/TestWeaviateDataWriter.scala
+++ b/src/test/scala/TestWeaviateDataWriter.scala
@@ -106,5 +106,23 @@ class TestWeaviateDataWriter extends AnyFunSuite {
     }
   }
 
-
+  test("Test write batch and with unresponsive Weaviate server") {
+    val options: CaseInsensitiveStringMap =
+      new CaseInsensitiveStringMap(Map("scheme" -> "http", "host" -> "localhost", "className" -> "Article").asJava)
+    val weaviateOptions: WeaviateOptions = new WeaviateOptions(options)
+    val structFields = Array[StructField](
+      StructField("id", DataTypes.StringType, true, Metadata.empty),
+      StructField("title", DataTypes.StringType, true, Metadata.empty),
+      StructField("content", DataTypes.StringType, true, Metadata.empty),
+      StructField("wordCount", DataTypes.IntegerType, true, Metadata.empty)
+    )
+    val schema = StructType(structFields)
+    val dw = WeaviateDataWriter(weaviateOptions, schema)
+    val sam = UTF8String.fromString("Sam")
+    val uuid = java.util.UUID.randomUUID.toString
+    val row = new GenericInternalRow(Array[Any](UTF8String.fromString(uuid), sam, sam, 5))
+    val weaviateObject = dw.buildWeaviateObject(row)
+    dw.batch(uuid) = weaviateObject
+    dw.writeBatch(retries = 0)
+  }
 }

--- a/src/test/scala/TestWeaviateDataWriter.scala
+++ b/src/test/scala/TestWeaviateDataWriter.scala
@@ -123,6 +123,8 @@ class TestWeaviateDataWriter extends AnyFunSuite {
     val row = new GenericInternalRow(Array[Any](UTF8String.fromString(uuid), sam, sam, 5))
     val weaviateObject = dw.buildWeaviateObject(row)
     dw.batch(uuid) = weaviateObject
-    dw.writeBatch(retries = 0)
+    assertThrows[WeaviateResultError] {
+      dw.writeBatch(retries = 0)
+    }
   }
 }


### PR DESCRIPTION
An unresponsive weaviate server will cause a NPE when calling `result.getResult`. This PR adds a check to see if result.getResult == null and if so retry and if retries are 0 then throw a Weaviate specific exception with error message from Weaviate. 

This fixes #85 