### PR TITLE
Add support for gRPC when saving data

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 import ReleaseTransformations._
 
+resolvers += Resolver.mavenLocal
+
 ThisBuild / scalaVersion := "2.12.17"
 
 crossScalaVersions := Seq("2.12.17", "2.13.10")
@@ -13,16 +15,21 @@ lazy val root = (project in file("."))
 ThisBuild / scalafixDependencies += "org.scalalint" %% "rules" % "0.1.4"
 
 lazy val sparkVersion = "3.5.0"
-lazy val weaviateClientVersion = "4.3.0"
+lazy val weaviateClientVersion = "4.4.1"
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.17" % "test",
   "org.apache.spark" %% "spark-core" % sparkVersion % "provided,test",
   "org.apache.spark" %% "spark-sql" % sparkVersion % "provided,test",
   "org.apache.spark" %% "spark-catalyst" % sparkVersion % "provided,test",
   "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0",
-  "io.weaviate" % "client" % weaviateClientVersion
+  "io.weaviate" % "client" % weaviateClientVersion,
+  "io.grpc" % "grpc-netty-shaded" % "1.58.0"
 )
 
+assemblyShadeRules in assembly := Seq(
+  ShadeRule.rename("com.google.protobuf.**" -> "shade_proto.@1").inAll,
+  ShadeRule.rename("com.google.common.**" -> "shade_googlecommon.@1").inAll
+)
 
 ThisBuild / organization := "io.weaviate"
 ThisBuild / organizationName := "Weaviate B.V."

--- a/src/main/scala/WeaviateOptions.scala
+++ b/src/main/scala/WeaviateOptions.scala
@@ -38,6 +38,8 @@ class WeaviateOptions(config: CaseInsensitiveStringMap) extends Serializable {
       throw new WeaviateOptionsError(s"Invalid consistency level: ${value}")
     value
   }
+  val grpcSecured: Boolean = config.getBoolean(WEAVIATE_GRPC_SECURED, false)
+  val grpcHost: String = config.getOrDefault(WEAVIATE_GRPC_HOST, null)
 
   var headers: Map[String, String] = Map()
   config.forEach((option, value) => {
@@ -50,8 +52,7 @@ class WeaviateOptions(config: CaseInsensitiveStringMap) extends Serializable {
 
   def getClient(): WeaviateClient = {
     if (client != null) return client
-    val config = new Config(scheme, host, headers.asJava, timeout, timeout, timeout)
-
+    val config = new Config(scheme, host, headers.asJava, timeout, grpcSecured, grpcHost)
     if (!oidcUsername.trim().isEmpty() && !oidcPassword.trim().isEmpty()) {
       client = WeaviateAuthClient.clientPassword(config, oidcUsername, oidcPassword, null)
     } else if (!oidcClientSecret.trim().isEmpty()) {
@@ -88,4 +89,6 @@ object WeaviateOptions {
   val WEAVIATE_API_KEY: String = "apiKey"
   val WEAVIATE_HEADER_PREFIX: String = "header:"
   val WEAVIATE_CONSISTENCY_LEVEL: String = "consistencyLevel"
+  val WEAVIATE_GRPC_SECURED: String = "grpc:secured"
+  val WEAVIATE_GRPC_HOST: String = "grpc:host"
 }

--- a/src/test/scala/TestWeaviateOptions.scala
+++ b/src/test/scala/TestWeaviateOptions.scala
@@ -219,6 +219,59 @@ class TestWeaviateOptions extends AnyFunSuite {
     assert(weaviateOptions.headers.asJava.get("x-cohere-api-key") == "COHERE_KEY")
   }
 
+  test("Test enable gRPC is set correctly") {
+    val options: CaseInsensitiveStringMap =
+      new CaseInsensitiveStringMap(Map("scheme" -> "http", "host" -> "localhost",
+        "className" -> "pinball", "batchSize" -> "19", "retries" -> "5", "retriesBackoff" -> "5",
+        "apiKey" -> "apiKey", "grpc:secured" -> "true", "grpc:host" -> "localhost:50051").asJava)
+    val weaviateOptions: WeaviateOptions = new WeaviateOptions(options)
+
+    assert(weaviateOptions.scheme == "http")
+    assert(weaviateOptions.host == "localhost")
+    assert(weaviateOptions.className == "pinball")
+    assert(weaviateOptions.batchSize == 19)
+    assert(weaviateOptions.retries == 5)
+    assert(weaviateOptions.retriesBackoff == 5)
+    assert(weaviateOptions.timeout == 60)
+    assert(weaviateOptions.apiKey == "apiKey")
+    assert(weaviateOptions.grpcSecured)
+    assert(weaviateOptions.grpcHost == "localhost:50051")
+
+    val options2: CaseInsensitiveStringMap =
+      new CaseInsensitiveStringMap(Map("scheme" -> "http", "host" -> "localhost",
+        "className" -> "pinball", "batchSize" -> "19", "retries" -> "5", "retriesBackoff" -> "5",
+        "apiKey" -> "apiKey", "grpc:secured" -> "False").asJava)
+    val weaviateOptions2: WeaviateOptions = new WeaviateOptions(options2)
+
+    assert(weaviateOptions2.scheme == "http")
+    assert(weaviateOptions2.host == "localhost")
+    assert(weaviateOptions2.className == "pinball")
+    assert(weaviateOptions2.batchSize == 19)
+    assert(weaviateOptions2.retries == 5)
+    assert(weaviateOptions2.retriesBackoff == 5)
+    assert(weaviateOptions2.timeout == 60)
+    assert(weaviateOptions2.apiKey == "apiKey")
+    assert(!weaviateOptions2.grpcSecured)
+    assert(weaviateOptions2.grpcHost == null)
+
+    val options3: CaseInsensitiveStringMap =
+      new CaseInsensitiveStringMap(Map("scheme" -> "http", "host" -> "localhost",
+        "className" -> "pinball", "batchSize" -> "19", "retries" -> "5", "retriesBackoff" -> "5",
+        "apiKey" -> "apiKey").asJava)
+    val weaviateOptions3: WeaviateOptions = new WeaviateOptions(options3)
+
+    assert(weaviateOptions3.scheme == "http")
+    assert(weaviateOptions3.host == "localhost")
+    assert(weaviateOptions3.className == "pinball")
+    assert(weaviateOptions3.batchSize == 19)
+    assert(weaviateOptions3.retries == 5)
+    assert(weaviateOptions3.retriesBackoff == 5)
+    assert(weaviateOptions3.timeout == 60)
+    assert(weaviateOptions3.apiKey == "apiKey")
+    assert(!weaviateOptions3.grpcSecured)
+    assert(weaviateOptions3.grpcHost == null)
+  }
+
   test("Test that getConnection returns the same WeaviateClient object") {
     val options: CaseInsensitiveStringMap =
       new CaseInsensitiveStringMap(Map("scheme" -> "http", "host" -> "localhost:8080", "className" -> "pinball", "batchSize" -> "19").asJava)

--- a/src/test/scala/WeaviateDocker.scala
+++ b/src/test/scala/WeaviateDocker.scala
@@ -18,10 +18,11 @@ object WeaviateDocker {
   var retries = 10
 
   def start(vectorizerModule: String = "none", enableModules: String = "text2vec-openai"): Int = {
-    val weaviateVersion = "1.20.1"
+    val weaviateVersion = "1.22.4"
     val docker_run =
       s"""docker run -d --name=weaviate-test-container-will-be-deleted
 -p 8080:8080
+-p 50051:50051
 -e QUERY_DEFAULTS_LIMIT=25
 -e AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true
 -e DEFAULT_VECTORIZER_MODULE=$vectorizerModule


### PR DESCRIPTION
This PR adds support for `gRPC API` in `Spark connector`
in order to configure `gRPC` one needs to provide `grpc:host` and `grpc:secured` options.

Example:
```
df.write.format("io.weaviate.spark.Weaviate") \
            .option("scheme", "http") \
            .option("host", "localhost:8080") \
            .option("grpc:secured", "false") \
            .option("grpc:host", "localhost:50051") \
            .option("className", "Article") \
            .option("id", "id") \
            .mode("append").save()
```
