### PR TITLE
Fix date parsing for dates prior to 1970-01-01

### DIFF
--- a/src/main/scala/WeaviateDataWriter.scala
+++ b/src/main/scala/WeaviateDataWriter.scala
@@ -124,9 +124,9 @@ case class WeaviateDataWriter(weaviateOptions: WeaviateOptions, schema: StructTy
       case ArrayType(LongType, true) => throw new SparkDataTypeNotSupported(
         "Array of LongType is not supported. Convert to Spark Array of IntegerType instead")
       case DateType =>
-        // Weaviate requires an RFC3339 formatted string and Spark stores a long that
+        // Weaviate requires an RFC3339 formatted string and Spark stores an int that
         // contains the the days since EPOCH for DateType
-        val daysSinceEpoch = record.getLong(index)
+        val daysSinceEpoch = record.getInt(index)
         java.time.LocalDate.ofEpochDay(daysSinceEpoch).toString + "T00:00:00Z"
       case StructType(_) =>
         val dt = dataType.asInstanceOf[StructType]

--- a/src/test/scala/TestWeaviateDataWriter.scala
+++ b/src/test/scala/TestWeaviateDataWriter.scala
@@ -93,7 +93,7 @@ class TestWeaviateDataWriter extends AnyFunSuite {
     val dw = WeaviateDataWriter(weaviateOptions, schema)
     val sam = UTF8String.fromString("Sam")
     val javaDate = java.sql.Date.valueOf("2022-11-18")
-    val date = DateTimeUtils.fromJavaDate(javaDate).asInstanceOf[Long]
+    val date = DateTimeUtils.fromJavaDate(javaDate)
     val row = new GenericInternalRow(Array[Any](sam, sam, 5, date))
     val weaviateObject = dw.buildWeaviateObject(row)
 


### PR DESCRIPTION
This PR fixes a problem with dates before `1970-01-01`. Internally, Spark represents `DateType` values as the integer number of days since `1970-01-01`. Getting such values as `long` returns invalid values. 

For instance, the internal representation of `1969-12-31` is -1, but attempting to retrieve it as a long returned 4294967295 instead of -1. Consequently, subsequent code that tried to create a `java.time.LocalDate` from these invalid values produced invalid date-time strings, such as `+11761191-01-20T00:00:00Z`.

---

The current code works with `InternalRow` with [UnsafeRow](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java) as a concrete implementation. Instances of `UnsafeRow` are mutable binary rows backed by raw memory blocks outside the JVM. When accessing specific fields in `UnsafeRow`, we must carefully match types to prevent potential overflow values.